### PR TITLE
Minor tweaks (use `dist` folder, add watch script, update README)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 node_modules
 yarn.lock
 package-lock.json
-index.js
-index.mjs
+dist

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cd my-new-component
 npm install # or yarn
 ```
 
-Your component's source code lives in `src/index.html`.
+Your component's source code lives in `src/index.svelte`.
 
 TODO
 
@@ -28,6 +28,6 @@ TODO
 
 ## Consuming components
 
-Your package.json has a `"svelte"` field pointing to `src/index.html`, which allows Svelte apps to import the source code directly, if they are using a bundler plugin like [rollup-plugin-svelte](https://github.com/rollup/rollup-plugin-svelte) or [svelte-loader](https://github.com/sveltejs/svelte-loader) (where [`resolve.mainFields`](https://webpack.js.org/configuration/resolve/#resolve-mainfields) in your webpack config includes `"svelte"`). **This is recommended.**
+Your package.json has a `"svelte"` field pointing to `src/index.svelte`, which allows Svelte apps to import the source code directly, if they are using a bundler plugin like [rollup-plugin-svelte](https://github.com/rollup/rollup-plugin-svelte) or [svelte-loader](https://github.com/sveltejs/svelte-loader) (where [`resolve.mainFields`](https://webpack.js.org/configuration/resolve/#resolve-mainfields) in your webpack config includes `"svelte"`). **This is recommended.**
 
-For everyone else, `npm run build` will bundle your component's source code into a plain JavaScript module (`index.mjs`) and a UMD script (`index.js`). This will happen automatically when you publish your component to npm, courtesy of the `prepublishOnly` hook in package.json.
+For everyone else, `npm run build` will bundle your component's source code into a plain JavaScript module (`index.mjs`) and a UMD script (`index.js`) in the `dist` folder. This will happen automatically when you publish your component to npm, courtesy of the `prepublishOnly` hook in package.json.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "SvelteComponent",
   "svelte": "src/index.svelte",
-  "module": "index.mjs",
-  "main": "index.js",
+  "module": "dist/index.mjs",
+  "main": "dist/index.js",
   "scripts": {
     "build": "rollup -c",
+    "build:watch": "rollup -cw",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
@@ -17,8 +18,7 @@
     "svelte"
   ],
   "files": [
-    "src",
-    "index.mjs",
-    "index.js"
+    "dist",
+    "src"
   ]
 }


### PR DESCRIPTION
This changes the build so that the `index.js` and `index.mjs` are placed in a `dist` subfolder instead of the project root.

Also makes a minor fix to the README which was still referencing `index.html` instead of `index.svelte`.