### PR TITLE
Bump rollup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^6.0.0",
-    "rollup": "^1.20.0",
-    "rollup-plugin-svelte": "^5.0.0",
+    "@rollup/plugin-node-resolve": "^9.0.0",
+    "rollup": "^2.26.0",
+    "rollup-plugin-svelte": "^6.0.0",
     "svelte": "^3.0.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "rollup": "^2.26.0",
+    "rollup": "^2.0.0",
     "rollup-plugin-svelte": "^6.0.0",
     "svelte": "^3.0.0"
   },


### PR DESCRIPTION
All rollup dependencies (rollup itself + the plugins, also the svelte-plugin) did one or more major version jumps.