### PR TITLE
List svelte under peerDependencies and under rollup's external config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "rollup-plugin-svelte": "^6.0.0",
     "svelte": "^3.0.0"
   },
+  "peerDependencies": {
+    "svelte": "^3.0.0"
+  },
   "keywords": [
     "svelte"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ export default {
 		{ file: pkg.module, 'format': 'es' },
 		{ file: pkg.main, 'format': 'umd', name }
 	],
+	external: ['svelte', 'svelte/internal'],
 	plugins: [
 		svelte(),
 		resolve()


### PR DESCRIPTION
... so that:

1. `peerDependencies` so that a duplicate copy of Svelte doesn't get installed under `node_modules` in apps that consume this new component/library

2. `external` so that a duplicate copy of Svelte doesn't get included inline as part of the (component's/library's) `dist` bundle that rollup builds

## Advantages of this change

### Prevents "Function called outside component initialization" error caused by _only_ listing `svelte` as an external

I learned the hard way (see [this write-up](https://stackoverflow.com/questions/64152594/should-svelte-libraries-include-external-svelte-in-rollup-config-js-func) for more details and background) that having multiple copies of Svelte ending up in an app's bundle can in certain cases result in a "Function called outside component initialization" error.

To be precise, I believe the problem only occurs when you only have `external: ['svelte']` listed in the library's `rollup.config.js`, but not also `'svelte/internal'` (as I proved to myself in [this commit](https://github.com/TylerRick/repro_getContext_from_comp_inside_each/commit/0c78b58bef1a4fb3f6d73e5370b160de71856314)).

I _eventually_ figured out that only listing `svelte` causes it to only _partially_ "externalized" svelte, causing my new library's bundle to end up containing an holy mix of references to both an _external_ copy of Svelte (the public API) and an _internal_ copy of Svelte (the internal API) ... which couldn't see each other or share their copy of `let current_component` with each other, which is what caused this error. But how was I to know that? Listing only `svelte` there seemed like a pretty reasonable thing to do at the time.

I wish there were a big warning somewhere (where?) that warned that if you are going to externalize svelte, you actually need to list _both_ of these entrypoints:
```
  external: ['svelte/internal', 'svelte'],
```
instead of just:
```
  external: ['svelte'],
```

I also wish I understood _why_ exactly that is necessary. To someone new to rollup and svelte, that was surprising.

Now it's possible that I'm the only one who has run into this particular problem, but it's also possible that I'm not the only one.

Anyway, if we included that configuration by default in this template, it might help future developers from wasting a day of debugging trying to figure out the cause of that strange error.

### Smaller bundle size

This change has the added benefit of making the component's/library's bundle size much smaller (see this [before and after repo]):

```
⟫ wc dist/index.mjs 
  12   34  294 dist/index.mjs  # Before
 230  674 6955 dist/index.mjs  # After
```

## Is this change safe/reasonable for all use cases?

My thinking is that since projects generated from this template won't be used in a stand-alone way — they will be consumed from a Svelte _app_ — then it's safe to assume and require that the app already includes a copy of `svelte` in their `package.json`/`node_modules`.

But it's possible I'm not considering all use cases (like SSR and using as web components) and that my assumptions are only true for the "normal app" case.

I think the main downside/risk of this change is that it assumes/requires that _all_ Svelte component/library modules that you import into your app _can_ share a single copy and a single _version_ of Svelte. (I guess if they are built against the same _version_ of Svelte, then of course they could share the same _copy_ of Svelte.)

**Is the Svelte API (including `svelte/internal`??) considered stable enough that sharing one copy of it** across all components should generally be pretty safe?

Would one only run into problems if there was a new major Svelte version and some components were built against the old version and some against the new major version?

If one were using a heavier run-time like React or Angular, then it seems like _of course_ you would do it this way (use `peerDependencies` + `external`) to make sure you only end up with only _1_ copy of React/Angular/etc. in your _app_ project and _0_ copies included in the dist bundle of any _library_ projects.

I'm just trying to figure out (since I'm new to Svelte) if Svelte...

1. is just fundamentally different, since the components are statically compiled, (and not expected to share any internal state across project boundaries?); or
2. is _basically_ the same (since it still has a run-time and a public API) in principle, but since its run-time is so small, most Svelte devs just haven't noticed or cared about the small extra bundle size that could result from including multiple "copies" of Svelte.

The other thing to consider about this change is that either way you go, it seems like we are preventing one option...
1. If Svelte libraries get built _with_ these `external`s, then there's no way for an app to use 2 different Svelte libraries that each require different, incompatible versions of Svelte.
    - (It also requires `svelte` to be a `peerDependency`, which makes sense for a "normal" Svelte app, but maybe not for an app that is not primarily a Svelte app that wants to consume a Svelte component as a web component?)
2. But if the same Svelte libraries get built _without_ the `external`, then the library consumers are stuck with the extra copies of Svelte and there's no way to get rid of them. 
    - (At least I don't _think_ there's any way that features like tree shaking would help with that, since the copies are included inline in the bundle and there's no way the app's bundler could know which Svelte functions are the same/compatible across 2 different Svelte libraries.).

I guess it comes down to "static linking" vs. "dynamic linking". For things like web components, it's probably necessary to have it "statically linked"/self-contained. But for the "normal app" use case, it seems preferable to just have one copy of any frontend framework.

It's too bad there's no way to build it both ways... Or is there? Is there a way to have a different list of `external`s for each of your `output` blocks, so you could build your library both ways?

It seems like there might be other things that would need to be different depending on whether the component were going to be consumed as a web component or not... like the presence of `<svelte:options tag="component-name">` and `customElement: true` ... which it might be nice to have separate builds for both, or allow the component consumer to control somehow.


## Conclusion

If this configuration seems like a best practice, then we should include it as part of the official template so that users (especially relatively new Svelte developers like myself) won't have to remember to manually make this change on any new Svelte components/libraries they build, and won't end up with multiple copies of Svelte (small though its run-time may be) included in their app's bundle.

Or if this is considered a _bad_ practice, perhaps we should warn against it, somewhere in the Svelte docs... :smile: 

Having the config like has worked well for me so far. But I wanted to get some feedback about potential downsides to this approach, and if possible save people from making the same mistakes that I made.