### PR TITLE
Update link to SvelteKit package command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*Psst — looking for a more complete solution? Check out [SvelteKit](https://kit.svelte.dev) and its [package command](https://kit.svelte.dev/docs#packaging) which gives you more built-in features like TypeScript transpilation, type definition generation and a built-in playground to test your library.*
+*Psst — looking for a more complete solution? Check out [SvelteKit](https://kit.svelte.dev) and its [package command](https://kit.svelte.dev/docs/packaging) which gives you more built-in features like TypeScript transpilation, type definition generation and a built-in playground to test your library.*
 
 *Looking for an app template instead? Go here --> [sveltejs/template](https://github.com/sveltejs/template)*
 


### PR DESCRIPTION
It looks like SvelteKit's docs for packaging have moved.

Alternatively, it could link to https://kit.svelte.dev/docs/cli#svelte-kit-package, but that section says
>See [packaging](https://kit.svelte.dev/docs/packaging).